### PR TITLE
Fix not obtaining values when whitespaces at left

### DIFF
--- a/dhcpd_to_unbound.py
+++ b/dhcpd_to_unbound.py
@@ -44,7 +44,7 @@ def parse_file(filename):
 
     with open(filename) as fp:
         for line in fp:
-            words = line.split(' ')
+            words = line.strip().split(' ')
 
             if line.startswith('lease'):
                 if current_ip is not None and current_ip not in leases:

--- a/dhcpd_to_unbound.py
+++ b/dhcpd_to_unbound.py
@@ -85,12 +85,13 @@ def write_output(leases, domain_name):
     print('# DNS A records for active DHCP (dhcpd) leases\n'
           '#\n'
           '# File created using dhcp_to_unbound '
-          '(https://github.com/bceverly/dhcp_to_unbound)\n')
+          '(https://github.com/bceverly/dhcp_to_unbound)\n'
+          'server:\n')
 
     for key, value in leases.items():
         if not (value.abandoned or value.hostname is None):
-            print(f'local-data: "{value.hostname}.{domain_name}. IN A {key}"\n'
-                  f'local-data-ptr: "{key} {value.hostname}.{domain_name}"\n')
+            print(f'  local-data: "{value.hostname}.{domain_name}. IN A {key}"\n'
+                  f'  local-data-ptr: "{key} {value.hostname}.{domain_name}"\n')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I tested your script and at first glance, it's not worked at all. After I while I realized that the "dhcpd" creates the "dhcpd.leases" file with indentation. Which makes that the script add blank keys at the array before the intended words. Just adding the strip command fixed the issue.